### PR TITLE
option: Add serde(default) to the example

### DIFF
--- a/src/option.rs
+++ b/src/option.rs
@@ -8,6 +8,7 @@
 //!
 //! #[derive(Serialize, Deserialize)]
 //! struct Foo {
+//!     #[serde(default)]
 //!     #[serde(with = "humantime_serde::option")]
 //!     timeout: Option<Duration>,
 //!     #[serde(default)]


### PR DESCRIPTION
Otherwise, serde insists on the field being present, and won't
deserialize an absent field to None.

Discovered during the addition of tests to Arti.